### PR TITLE
Feature/devise email confirmation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,8 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 
-  gem "letter_opener"
-  gem 'letter_opener_web', '~> 1.0'
+  gem 'letter_opener'
+  gem 'letter_opener_web'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ group :development do
   gem 'listen', '~> 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+
+  gem "letter_opener"
+  gem 'letter_opener_web', '~> 1.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,14 @@ GEM
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (1.4.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -111,9 +119,13 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.7)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nokogiri (1.11.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -268,6 +280,8 @@ DEPENDENCIES
   factory_bot_rails
   hamlit-rails
   jbuilder (~> 2.7)
+  letter_opener
+  letter_opener_web (~> 1.0)
   listen (~> 3.2)
   pg
   puma (~> 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ DEPENDENCIES
   hamlit-rails
   jbuilder (~> 2.7)
   letter_opener
-  letter_opener_web (~> 1.0)
+  letter_opener_web
   listen (~> 3.2)
   pg
   puma (~> 4.1)

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,10 +1,9 @@
 class ConfirmationsController < Devise::ConfirmationsController
-  
   private
 
-  def after_confirmation_path_for(resource_name, resource)
+  def after_confirmation_path_for(_resource_name, resource)
     sign_in(resource)
-    
+
     # Redirect to whatever page you want
     root_path
   end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,11 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  
+  private
+
+  def after_confirmation_path_for(resource_name, resource)
+    sign_in(resource)
+    
+    # Redirect to whatever page you want
+    root_path
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  # before_action :authenticate_user!, except: [:index]
+
   def index
     @item = Item.find_by(id: params[:id])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
+
   validates :first_name, :last_name, :contact, :address, presence: true
 
   has_many :items, dependent: :restrict_with_exception

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,10 @@
-<p>Welcome <%= @email %>!</p>
+<!--<h1>Welcome <%= @email %>!</h1>-->
 
-<p>You can confirm your account email through the link below:</p>
+<h3>Welcome to <strong>Kalakalph</strong>, <%= @user.first_name %>!</h3>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p>You are now part of a community that connects different people with different needs around the world. With over 200,000 unique users, there will be no shortage of interesting finds that will catch your interest.
+Find an item you want. Negotiate your way through a deal. Discover things you can do.</p>
+
+<p>Please confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token), target: '_blank' %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,8 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  # Letter Opener
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,4 +109,9 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.action_mailer.default_url_options = { host: 'https://kalakalph.herokuapp.com/'}
+
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,8 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  # config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'notifications@kalakalph.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -157,7 +158,8 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  # config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  mount LetterOpenerWeb::Engine, at: "/letter_opener"
   
   devise_for :users, controllers: {
     confirmations: 'confirmations'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,15 @@
 Rails.application.routes.draw do
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   
+  devise_for :users, controllers: {
+    confirmations: 'confirmations'
+  }
+  
   root to: 'home#index'
   
   get '/items/:id' => 'items#index', as: 'items_index'
   post '/items/create/:id' => 'items#create', as: 'items_create'
-  devise_for :users
+  
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  
   root to: 'home#index'
   
   get '/items/:id' => 'items#index', as: 'items_index'

--- a/db/migrate/20210714015124_add_devise_confirmable_to_users.rb
+++ b/db/migrate/20210714015124_add_devise_confirmable_to_users.rb
@@ -1,0 +1,7 @@
+class AddDeviseConfirmableToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_13_133202) do
+ActiveRecord::Schema.define(version: 2021_07_14_015124) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,9 @@ ActiveRecord::Schema.define(version: 2021_07_13_133202) do
     t.text "address"
     t.string "contact"
     t.decimal "ave_rating"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
This PR requires users to confirm their email before they can use the app (e.g. add, edit, update items, etc). But for now, it redirects to the root_path as the home#index has logic to check the current user and render an appropriate view. 

This also adds the letter opener mail previewer both in the development and production (to be tested) environment.

**Confirmation message upon successful sign-up**

![img01](https://user-images.githubusercontent.com/38428303/125556872-63e71c55-62d6-4f7c-8148-09646a50989e.jpg)

**Email confirmation to be received via email**

![img02](https://user-images.githubusercontent.com/38428303/125556933-e47d3e92-b3e1-43d3-8ee4-1bf36e53cd18.jpg)

**Message confirmation once email is confirmed**

![img03](https://user-images.githubusercontent.com/38428303/125556971-41a0a582-e56f-4481-976b-ed3b1a88f13f.jpg)
