### PR TITLE
Features/james/chat

### DIFF
--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -23,6 +23,15 @@
 .conversation-container {
     height: 90vh;
     
+    .convo_partner {
+        font-size: 0.8rem;
+        color: #777777;
+    }
+
+    .item-status-update {
+        width: 27%;
+    }
+
     .messages-container {
         height: 90%;
         border: 1px solid #7777773f;

--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -62,21 +62,39 @@
                     color: #777777;
                     margin-left: 10px;
                 }
+
+                .message-created_at {
+                    font-size: 0.7rem;
+                    color: #777777;
+                    margin-left: 10px;
+                }
             }
 
             &.me {
                 .content-container {
                     float: right;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-end;
 
                     .content {
                         color: white;
                         background-color: #007bff;
                     }
-                }
-            }
-            
-        }
 
+                    .author-date {
+                        align-items: flex-end;
+                        margin-right: 10px;
+
+                        .author {
+                            font-size: 0.8rem;
+                            color: #777777;
+                        }
+
+                    }
+                }
+            }    
+        }
     }
 
     .message-form {

--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -29,7 +29,13 @@
     }
 
     .item-status-update {
-        width: 27%;
+        width: 28%;
+
+        .modal {
+            .text-danger {
+                font-size: 0.8rem;
+            }
+        }
     }
 
     .messages-container {

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,52 +1,96 @@
 * {
-  margin: 0;
-  padding: 0;
-  text-decoration: none;
-}
-
-.products {
-  max-width: 65rem;
-  height: auto;
-  padding: 1rem;
-  display: flex;
-  flex-flow: wrap;
-  justify-content: center;
-  align-items: flex-start;
-}
-
-.items {
-  border: 0.1rem solid #c5c8ca;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  height: 20rem;
-  width: 17.5rem;
-  padding: 1rem;
-  margin: 1rem;
-}
-
-.itempic {
-  height: 100%;
-  width: 100%;
-  object-fit: cover;
-}
-
-.item_name {
-  margin-top: 0.5rem;
-}
-
-.post_item, .down {
-  margin-top: 1rem;
-}
-
-
-.tmp-sidebar {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 15vw;
-    background-color: white;
-    border-right: 1px solid #79797967;
-}
+    margin: 0;
+    padding: 0;
+    text-decoration: none;
+  }
+  
+  .products {
+    max-width: 65rem;
+    height: auto;
+    padding: 1rem;
+    display: flex;
+    flex-flow: wrap;
+    justify-content: center;
+    align-items: flex-start;
+  }
+  
+  .items {
+    border: 0.1rem solid #c5c8ca;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    height: 20rem;
+    width: 17.5rem;
+    padding: 1rem;
+    margin: 1rem;
+  }
+  
+  .itempic {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+  }
+  
+  .item_name {
+    margin-top: 0.5rem;
+  }
+  
+  .post_item, .down {
+    margin-top: 1rem;
+  }
+  
+  /* bootstrap bg primary: #007bff */
+  
+  .tmp-sidebar {
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      box-shadow: rgba(0, 0, 0, 0.15) 2.4px 2.4px 3.2px;
+      
+    .hello-username {
+      //   background-color: red;
+        height: 5rem;
+        margin-bottom: 20px !important;
+    }
+  
+    .nav-items-container {
+      //   background-color: green;
+    }
+  
+    .conversations {
+      //   background-color: yellow;
+        height: 60vh;
+        overflow-y: auto;
+  
+        .nav-item {
+            border-radius: 5px;
+  
+            &:hover {
+              background-color: #e0e0e0;
+            }
+          
+            &.active {
+                  background-color: #007bff;
+  
+                  .convo-item-name {
+                      color: white;
+                  }
+  
+                  .other-user-username {
+                      color: #5a5a5a;
+                  }
+            }
+  
+            
+  
+          .other-user-username {
+              font-size: 0.8rem;
+              color: #777777;
+          }
+        }
+    }
+  }
+  
+  

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,7 +16,7 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find_by(id: params[:id])
-    redirect_to item_path(item.id) if item.update(item_params)
+    redirect_to request.referrer if item.update(item_params)
   end
 
   def delete

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,7 +16,7 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find_by(id: params[:id])
-    redirect_to request.referrer if item.update(item_params)
+    redirect_to request.referer if item.update(item_params)
   end
 
   def delete

--- a/app/javascript/channels/conversation_channel.js
+++ b/app/javascript/channels/conversation_channel.js
@@ -5,6 +5,7 @@ document.addEventListener('turbolinks:load', () => {
     const conversation_id = Number(conversation_element.getAttribute('data-conversation-id'));
     const send_button = document.getElementById('send-btn');
     const input_box = document.getElementById('message-input-box');
+    const messages_container = document.getElementById('messages-container');
 
     // for terminating other subscriptions when connected to a new subscription
     consumer.subscriptions.subscriptions.forEach(subs => {
@@ -14,6 +15,7 @@ document.addEventListener('turbolinks:load', () => {
     consumer.subscriptions.create({ channel: "ConversationChannel", conversation_id: conversation_id }, {
         connected() {
           // Called when the subscription is ready for use on the server
+          messages_container.scrollTop = messages_container.scrollHeight;
         },
       
         disconnected() {
@@ -33,6 +35,7 @@ document.addEventListener('turbolinks:load', () => {
       
           send_button.disabled = false;
           input_box.value = '';
+          messages_container.scrollTop = messages_container.scrollHeight;
         }
       });
 });

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -81,8 +81,12 @@
       </div> 
 
       <div class="messages-container mb-2 rounded-lg" id="messages-container">
-        <% @conversation.messages.each do |message| %>
-          <%= render 'messages/message', message: message %>
+        <% @conversation.messages.each_with_index do |message, i| %>
+          <% if i >= 0 %>
+            <!-- checking time difference between messages in minutes -->
+            <% time_diff = (message.created_at - @conversation.messages[i-1].created_at)/60.to_i %>
+          <% end %>
+          <%= render 'messages/message', message: message, time_diff: time_diff %>
         <% end %>
       </div>
 

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -22,6 +22,8 @@
         <div>
           <span><%= @conversation.item.name %></span>
           <span class="convo_partner"><%= convo_partner %></span>
+          <% status = @conversation.item.status == 'open' ? '' : "(" + @conversation.item.status.capitalize + ")"%>
+          <span class="status font-italic text-warning"><%= status %></span>
         </div>
 
         <div class="item-status-update d-flex justify-content-around">
@@ -40,16 +42,39 @@
             <% end %>
 
             <% if @conversation.item.status != 'traded' %>
-                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                    <%= f.hidden_field :status, value: "traded" %>
-                    <%= f.submit "Mark as Traded", class: "btn btn-primary" %>
-                <% end %>
+                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#staticBackdrop">Mark as Traded</button>
             <% else %>
                 <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
                     <%= f.hidden_field :status, value: "open" %>
                     <%= f.submit "Unmark as Traded", class: "btn btn-primary" %>
                 <% end %>
             <% end %>
+
+            <!-- change item status to traded verification modal -->
+            <div class="modal fade" id="staticBackdrop" data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="staticBackdropLabel">Modal title</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div>Please verify that you wish to change this item's status to Traded.</div>
+                        <div class="text-danger">Note: Once confirmed, you will not be able to edit it afterwards.</div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                        <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                            <%= f.hidden_field :status, value: "traded" %>
+                            <%= f.submit "Mark as Traded", class: "btn btn-primary" %>
+                        <% end %>
+                        <!--<button type="button" class="btn btn-primary">Understood</button>-->
+                    </div>
+                    </div>
+                </div>
+            </div>
         </div>
       </div> 
 

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -9,25 +9,63 @@
       <div id="conversation-id" data-conversation-id="<%= @conversation.try(:id) %>"></div>
       <div id="user-id" data-user-id="<%= current_user.id %>"></div>
 
-      <h6><%= @conversation.item.name %></h6>
-      <!--displaying username of current_user's conversation partner -->
+      <!-- getting username of current_user's conversation partner -->
       <% if @conversation.item.user == current_user && current_user.id == @conversation.user2_id %>
-        <p><%= User.find(@conversation.user1_id).username %></p>
+        <span><% convo_partner = User.find(@conversation.user1_id).username %></span>
       <% elsif @conversation.item.user == current_user && current_user.id == @conversation.user1_id %>
-        <p><%= User.find(@conversation.user2_id).username %></p>  
+        <span><% convo_partner = User.find(@conversation.user2_id).username %></span>  
       <% else %>
-        <p><%= @conversation.item.user.username %></p>  
+        <span><% convo_partner = @conversation.item.user.username %></span>  
       <% end %>
+
+      <div class="d-flex justify-content-between align-items-center mb-2 mt-2">
+        <div>
+          <span><%= @conversation.item.name %></span>
+          <span class="convo_partner"><%= convo_partner %></span>
+        </div>
+
+        <div class="item-status-update d-flex justify-content-around">
+            <% disabled = @conversation.item.status == 'traded' %>
+
+            <% if @conversation.item.status != 'reserved'%>
+                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                    <%= f.hidden_field :status, value: "reserved" %>
+                    <%= f.submit "Mark as Reserved", disabled: disabled, class: "btn btn-primary" %>
+                <% end %>
+            <% else %>
+                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                    <%= f.hidden_field :status, value: "open" %>
+                    <%= f.submit "Mark as Open", disabled: disabled, class: "btn btn-primary" %>
+                <% end %>
+            <% end %>
+
+            <% if @conversation.item.status != 'traded' %>
+                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                    <%= f.hidden_field :status, value: "traded" %>
+                    <%= f.submit "Mark as Traded", class: "btn btn-primary" %>
+                <% end %>
+            <% else %>
+                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                    <%= f.hidden_field :status, value: "open" %>
+                    <%= f.submit "Unmark as Traded", class: "btn btn-primary" %>
+                <% end %>
+            <% end %>
+        </div>
+      </div> 
+
       <div class="messages-container mb-2 rounded-lg" id="messages-container">
         <% @conversation.messages.each do |message| %>
           <%= render 'messages/message', message: message %>
         <% end %>
       </div>
+
       <div class="message-form">
         <%= render 'messages/form' %>
       </div>
+
     <% else %>
       <h1>Item has been removed by User</h1>
     <% end %>
+
   </div>
 </section>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -56,7 +56,7 @@
                     <div class="modal-dialog">
                         <div class="modal-content">
                         <div class="modal-header">
-                            <h5 class="modal-title" id="staticBackdropLabel">Modal title</h5>
+                            <h5 class="modal-title" id="staticBackdropLabel">Mark item as Traded</h5>
                             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
                             </button>
@@ -69,7 +69,7 @@
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
                             <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
                                 <%= f.hidden_field :status, value: "traded" %>
-                                <%= f.submit "Mark as Traded", class: "btn btn-primary" %>
+                                <%= f.submit "Proceed, mark as Traded", class: "btn btn-primary" %>
                             <% end %>
                             <!--<button type="button" class="btn btn-primary">Understood</button>-->
                         </div>

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -26,56 +26,58 @@
           <span class="status font-italic text-warning"><%= status %></span>
         </div>
 
-        <div class="item-status-update d-flex justify-content-around">
-            <% disabled = @conversation.item.status == 'traded' %>
+        <% if @conversation.item.user == current_user %>
+            <div class="item-status-update d-flex justify-content-around">
+                <% disabled = @conversation.item.status == 'traded' %>
 
-            <% if @conversation.item.status != 'reserved'%>
-                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                    <%= f.hidden_field :status, value: "reserved" %>
-                    <%= f.submit "Mark as Reserved", disabled: disabled, class: "btn btn-primary" %>
+                <% if @conversation.item.status != 'reserved'%>
+                    <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                        <%= f.hidden_field :status, value: "reserved" %>
+                        <%= f.submit "Mark as Reserved", disabled: disabled, class: "btn btn-primary" %>
+                    <% end %>
+                <% else %>
+                    <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                        <%= f.hidden_field :status, value: "open" %>
+                        <%= f.submit "Mark as Open", disabled: disabled, class: "btn btn-primary" %>
+                    <% end %>
                 <% end %>
-            <% else %>
-                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                    <%= f.hidden_field :status, value: "open" %>
-                    <%= f.submit "Mark as Open", disabled: disabled, class: "btn btn-primary" %>
-                <% end %>
-            <% end %>
 
-            <% if @conversation.item.status != 'traded' %>
-                <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#staticBackdrop">Mark as Traded</button>
-            <% else %>
-                <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                    <%= f.hidden_field :status, value: "open" %>
-                    <%= f.submit "Unmark as Traded", class: "btn btn-primary" %>
+                <% if @conversation.item.status != 'traded' %>
+                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#staticBackdrop">Mark as Traded</button>
+                <% else %>
+                    <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                        <%= f.hidden_field :status, value: "open" %>
+                        <%= f.submit "Unmark as Traded", class: "btn btn-primary" %>
+                    <% end %>
                 <% end %>
-            <% end %>
 
-            <!-- change item status to traded verification modal -->
-            <div class="modal fade" id="staticBackdrop" data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-                <div class="modal-dialog">
-                    <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="staticBackdropLabel">Modal title</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <div>Please verify that you wish to change this item's status to Traded.</div>
-                        <div class="text-danger">Note: Once confirmed, you will not be able to edit it afterwards.</div>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                        <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                            <%= f.hidden_field :status, value: "traded" %>
-                            <%= f.submit "Mark as Traded", class: "btn btn-primary" %>
-                        <% end %>
-                        <!--<button type="button" class="btn btn-primary">Understood</button>-->
-                    </div>
+                <!-- change item status to traded verification modal -->
+                <div class="modal fade" id="staticBackdrop" data-backdrop="static" data-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="staticBackdropLabel">Modal title</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <div>Please verify that you wish to change this item's status to Traded.</div>
+                            <div class="text-danger">Note: Once confirmed, you will not be able to edit it afterwards.</div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                            <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                                <%= f.hidden_field :status, value: "traded" %>
+                                <%= f.submit "Mark as Traded", class: "btn btn-primary" %>
+                            <% end %>
+                            <!--<button type="button" class="btn btn-primary">Understood</button>-->
+                        </div>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        <% end %>
       </div> 
 
       <div class="messages-container mb-2 rounded-lg" id="messages-container">

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -1,28 +1,62 @@
-<div class="tmp-sidebar">
-  <h6>temporary sidebar</h6>
-  <br>
-  <h5>Hello, <%= current_user.first_name %></h5>
-  <br>
-
-  <% @conversations.each do |conv| %>
-    <% if conv.item != nil %>
-      <%= link_to item_conversation_path(conv.item_id, conv.id) do %>
-        <div class="card">
-          <div class="card-body"> 
-            <h6><%= conv.item.name %></h6>
-            <!--displaying username of current_user's conversation partner -->
-            <% if conv.item.user == current_user && current_user.id == conv.user2_id %>
-              <p><%= User.find(conv.user1_id).username %></p>
-            <% elsif conv.item.user == current_user && current_user.id == conv.user1_id %>
-              <p><%= User.find(conv.user2_id).username %></p>  
-            <% else %>
-              <p><%= conv.item.user.username %></p>  
-            <% end %>
-          </div>
-        </div>
-      <% end %>  
-    <% end %>    
+<div class="tmp-sidebar d-flex flex-column flex-shrink-0 p-3 bg-light justify-content-start" style="width: 280px;">
+  <%= link_to root_path, class: "hello-username d-flex align-items-center mb-3 mb-md-0 me-md-auto link-dark text-decoration-none" do %>
+    <svg class="bi me-2" width="40" height="32"><use xlink:href="#bootstrap"></use></svg>
+    <span class="fs-4">Hello, <%= current_user.username %></span>
   <% end %>
+
+
+    <ul class="nav-items-container nav nav-pills flex-column mb-auto">
+        <li class="nav-item">
+            <a href="#" class="nav-link active" aria-current="page">
+            <svg class="bi me-2" width="16" height="16"><use xlink:href="#home"></use></svg>
+                Dashboard
+            </a>
+        </li>
+        <li>
+            <a href="#" class="nav-link link-dark">
+                <svg class="bi me-2" width="16" height="16"><use xlink:href="#speedometer2"></use></svg>
+                My listings
+            </a>
+        </li>
+
+        <li>
+            <a href="#" class="nav-link link-dark">
+                <svg class="bi me-2" width="16" height="16"><use xlink:href="#speedometer2"></use></svg>
+                Create listing
+            </a>
+        </li>
+        <li>
+            <a href="#" class="nav-link link-dark">
+                <svg class="bi me-2" width="16" height="16"><use xlink:href="#speedometer2"></use></svg>
+                History
+            </a>
+        </li>
+    </ul>
+
+    <h6>Conversations</h6>
+    <ul class="conversations nav nav-pills flex-column mb-auto">
+        <% @conversations.each do |conv| %>
+            <% if conv.item != nil %>
+                    <%= link_to item_conversation_path(conv.item_id, conv.id), class: "nav-link" do %>
+                        <% active_class = (@conversation == conv) ? 'active' : '' %>
+                        <li class="nav-item d-flex flex-column align-items-center <%= active_class %>">
+                            <span class="convo-item-name"><%= conv.item.name %></span>
+                            <!--displaying username of current_user's conversation partner -->
+                            <% if conv.item.user == current_user && current_user.id == conv.user2_id %>
+                                <span class="other-user-username"><%= User.find(conv.user1_id).username %></span>
+                            <% elsif conv.item.user == current_user && current_user.id == conv.user1_id %>
+                                <span class="other-user-username"><%= User.find(conv.user2_id).username %></span>
+                            <% else %>
+                                <span class="other-user-username"><%= conv.item.user.username %></span>
+                            <% end %>
+                        </li> 
+                    <% end %>
+            <% end %>    
+        <% end %>
+    </ul>
+
+
+
 
   <% if @conversations != nil %>
     <%= javascript_pack_tag 'sidebar.js' %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -71,7 +71,7 @@
                     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                       <a class="dropdown-item edit" id=<%= t.id %>>Edit Comment</a>
                       <%= form_with scope: :comment, method: :delete, url: delete_comment_path(t.id), local: true do |f| %>
-                        <%= f.submit :"Delete Comment", :class => "dropdown-item" %>
+                        <%= f.submit "Delete Comment", :class => "dropdown-item" %>
                       <% end %>
                     </div>
                   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -12,7 +12,7 @@
       <% if @item != nil %>
         <div class="item">
           <div class="item_details">
-            <h6 class="item_description"><%= @item.user.first_name %> <%= @item.user.last_name %></h6>
+            <h6 class="item_description"><%= @item.user.username %></h6>
             <% if user_signed_in? %>
               <% if current_user.id === @item.user_id %>
                 <div class="dropdown">

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with scope: :message, url: item_conversation_messages_path(@conversation.item.id, @conversation.id), local: true do |f| %>
+<%= form_with scope: :message, url: item_conversation_messages_path(@conversation.item.id, @conversation.id), local: false, remote: true do |f| %>
     <div class="form-inline">
     <%= f.hidden_field :conversation_id, value: @conversation.id %>
     <%= f.hidden_field :user_id, value: current_user.id %>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -4,7 +4,8 @@
     <%= f.hidden_field :user_id, value: current_user.id %>
         
     <%= f.text_field :content, placeholder: 'Type your message here...', class: 'form-control mr-2', id: 'message-input-box' %>
-    <%= f.submit 'Send', id: 'send-btn', class: 'btn btn-primary' %>
-        
+    <% disabled = @conversation.item.status == 'traded' %>
+    <%= f.submit 'Send', id: 'send-btn', class: 'btn btn-primary', disabled: disabled %>
+    
     </div>
 <% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,7 +1,13 @@
-<div class="message mb-3 <%= 'me' if message.user == current_user %>">
+<div class="message mb-4 <%= 'me' if message.user == current_user %>">
     <div class="content-container">
         <div class="content"><%= message.content %></div>
         <!--might remove author, when avatar is available-->
-        <div class="author"><%= message.user.username %></div>
+        <div class="d-flex flex-column author-date">
+            <div class="author"><%= message.user.username %></div>
+            <!-- displaying message.created_at if difference between this and previous message is > 5 mins -->
+            <% if time_diff > 5 %>
+                <div class="message-created_at font-italic"><%= message.created_at.strftime("%d-%m-%Y %I:%M%p") %></div>
+            <% end %>
+        </div>
     </div>
 </div>

--- a/notepad.md
+++ b/notepad.md
@@ -12,5 +12,9 @@
 
 
 ## bugs to fix:
-    -when user is not logged in, clicking a listing with comments returns an error
-    -when an exchange happened in a conversation, sometimes clicking on another conversation and clicking back to the previous conversation, the previous conversation doesn't show the recent exchange
+    1. when an exchange happened in a conversation, sometimes clicking on another conversation and clicking back to the previous conversation, the previous conversation doesn't show the recent exchange
+
+    2. after subscribing to a conversation, clicking a link other than the conversation links does not unsubscribe the user in the current conversation channel; clicking kalakalph which redirects the user to root should terminate the channel subscription
+
+## minor details to add:
+    1. channel broadcast when item's status is changed


### PR DESCRIPTION
This PR adds a few UI improvements on the sidebar and an option to change an item's status.

  - added a few placeholder nav-items in the sidebar
  - added a scrollable conversations container in the sidebar
  - item owner can now change an item's status to reserved or traded
      *when user is not the item's owner:
  ![image](https://user-images.githubusercontent.com/72240605/126025450-5e242cad-3977-4a7e-9e99-d0d47810064c.png)
      *when user is the item's owner:
![image](https://user-images.githubusercontent.com/72240605/126025456-f4a58bae-defe-4738-8d05-cca32c6a21fb.png)

  - changing item's status to 'traded' triggers a verification modal
  ![image](https://user-images.githubusercontent.com/72240605/126025463-5b9a1f93-e34d-437f-88c2-7a88adae5776.png)
  - changing item's status to either 'reserved' or 'traded' adds a new label on the conversation to denote item's status
  ![image](https://user-images.githubusercontent.com/72240605/126025484-1b1badb3-0d1c-4fdb-b3a0-7f4af9797ba7.png)

 - added fix to firefox chat bug
 - added auto scroll to conversation
 - added display of message creation dates