### PR TITLE
[HOTFIX] for user sign up error with no uploaded avatar

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,6 @@ class User < ApplicationRecord
   private
 
   def avatar_filesize
-    errors.add(:avatar, 'file size should not exceed 1 MB!') if avatar.byte_size >= 1.megabyte
+    errors.add(:avatar, 'file size should not exceed 1 MB!') if avatar.attached? && avatar.byte_size >= 1.megabyte
   end
 end


### PR DESCRIPTION
This PR fixes the error being encountered when a user signs up and does not upload an image for avatar