### PR TITLE
Features/james/transactions

### DIFF
--- a/app/assets/stylesheets/conversations.scss
+++ b/app/assets/stylesheets/conversations.scss
@@ -29,7 +29,7 @@
     }
 
     .item-status-update {
-        width: 28%;
+        width: auto;
 
         .modal {
             .text-danger {

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,8 +17,6 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find(params[:id])
-    Transact.create(item_id: params[:id], traded_with: 'chuchu', user2_id: params[:item][:buyer_id]) if params[:item][:status] == 'traded'
-
     transact = Transact.find_by(item_id: params[:id])
 
     if transact
@@ -27,6 +25,8 @@ class ItemsController < ApplicationController
         transact.delete
         item.transact_id = nil
       end
+    else
+        Transact.create(item_id: params[:id], traded_with: 'chuchu', user2_id: params[:item][:buyer_id]) if params[:item][:status] == 'traded'
     end
 
     redirect_to request.referer, notice: 'Listing was updated succesfully' if item.update(item_params)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,13 +20,13 @@ class ItemsController < ApplicationController
     transact = Transact.find_by(item_id: params[:id])
 
     if transact
-      item.transact_id = transact.id
       if params[:item][:status] == 'open'
         transact.delete
         item.transact_id = nil
       end
-    else
-        Transact.create(item_id: params[:id], traded_with: 'chuchu', user2_id: params[:item][:buyer_id]) if params[:item][:status] == 'traded'
+    elsif params[:item][:status] == 'traded'
+      new_transact = Transact.create(item_id: params[:id], traded_with: 'chuchu', user2_id: params[:item][:buyer_id]) if params[:item][:status] == 'traded'
+      item.transact_id = new_transact.id
     end
 
     redirect_to request.referer, notice: 'Listing was updated succesfully' if item.update(item_params)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,20 +17,18 @@ class ItemsController < ApplicationController
 
   def update
     item = Item.find(params[:id])
-    if params[:item][:status] == 'traded'
-        Transact.create(item_id: params[:id], traded_with: 'chuchu', user2_id: params[:item][:buyer_id])
-    end
+    Transact.create(item_id: params[:id], traded_with: 'chuchu', user2_id: params[:item][:buyer_id]) if params[:item][:status] == 'traded'
 
     transact = Transact.find_by(item_id: params[:id])
 
     if transact
-        item.transact_id = transact.id
-        if params[:item][:status] == 'open'
-            transact.delete
-            item.transact_id = nil 
-        end
+      item.transact_id = transact.id
+      if params[:item][:status] == 'open'
+        transact.delete
+        item.transact_id = nil
+      end
     end
-    
+
     redirect_to request.referer, notice: 'Listing was updated succesfully' if item.update(item_params)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
 
   def history
     @user = User.find(params[:id])
+    @conversations = current_user.conversations
     @history_items = @user.items.where(status: 'traded')
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,12 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+
   def show
+    @user = User.find(params[:id])
+    @conversations = current_user.conversations
+  end
+
+  def history
     @user = User.find(params[:id])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
 
   def history
     @user = User.find(params[:id])
+    @history_items = @user.items.where(status: 'traded')
   end
 
   # def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,9 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+
+  # def user_params
+  #     params.require(:user).permit()
+  # end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,7 @@ class Item < ApplicationRecord
   belongs_to :user
   has_many :conversations, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_one :transact
 
   # crop image to 300x300px and center
   def thumbnail(img)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to :user
   has_many :conversations, dependent: :destroy
   has_many :comments, dependent: :destroy
-  has_one :transact
+  has_one :transact, dependent: :nullify
 
   # crop image to 300x300px and center
   def thumbnail(img)

--- a/app/models/transact.rb
+++ b/app/models/transact.rb
@@ -1,0 +1,2 @@
+class Transact < ApplicationRecord
+end

--- a/app/models/transact.rb
+++ b/app/models/transact.rb
@@ -1,3 +1,3 @@
 class Transact < ApplicationRecord
-    belongs_to :item
+  belongs_to :item
 end

--- a/app/models/transact.rb
+++ b/app/models/transact.rb
@@ -1,2 +1,3 @@
 class Transact < ApplicationRecord
+    belongs_to :item
 end

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -31,25 +31,21 @@
             <div class="item-status-update d-flex justify-content-around">
                 <% disabled = @conversation.item.status == 'traded' %>
 
-                <% if @conversation.item.status != 'reserved'%>
-                    <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                        <%= f.hidden_field :status, value: "reserved" %>
-                        <%= f.submit "Mark as Reserved", disabled: disabled, class: "btn btn-primary" %>
-                    <% end %>
+                <% if @conversation.item.status == 'traded' %>
+                    <button type="button" class="btn btn-success ml-1 mr-1">Rate <%= convo_partner.username %></button>
                 <% else %>
-                    <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                        <%= f.hidden_field :status, value: "open" %>
-                        <%= f.submit "Mark as Open", disabled: disabled, class: "btn btn-primary" %>
+                    <% if @conversation.item.status != 'reserved'%>
+                        <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                            <%= f.hidden_field :status, value: "reserved" %>
+                            <%= f.submit "Mark as Reserved", disabled: disabled, class: "btn btn-primary ml-1 mr-1" %>
+                        <% end %>
+                    <% else %>
+                        <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                            <%= f.hidden_field :status, value: "open" %>
+                            <%= f.submit "Mark as Open", disabled: disabled, class: "btn btn-primary ml-1 mr-1" %>
+                        <% end %>
                     <% end %>
-                <% end %>
-
-                <% if @conversation.item.status != 'traded' %>
-                    <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#staticBackdrop">Mark as Traded</button>
-                <% else %>
-                    <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
-                        <%= f.hidden_field :status, value: "open" %>
-                        <%= f.submit "Unmark as Traded", class: "btn btn-primary" %>
-                    <% end %>
+                    <button type="button" class="btn btn-primary ml-1 mr-1" data-toggle="modal" data-target="#staticBackdrop">Mark as Traded</button>
                 <% end %>
 
                 <!-- change item status to traded verification modal -->

--- a/app/views/conversations/show.html.erb
+++ b/app/views/conversations/show.html.erb
@@ -11,21 +11,22 @@
 
       <!-- getting username of current_user's conversation partner -->
       <% if @conversation.item.user == current_user && current_user.id == @conversation.user2_id %>
-        <span><% convo_partner = User.find(@conversation.user1_id).username %></span>
+        <span><% convo_partner = User.find(@conversation.user1_id) %></span>
       <% elsif @conversation.item.user == current_user && current_user.id == @conversation.user1_id %>
-        <span><% convo_partner = User.find(@conversation.user2_id).username %></span>  
+        <span><% convo_partner = User.find(@conversation.user2_id) %></span>  
       <% else %>
-        <span><% convo_partner = @conversation.item.user.username %></span>  
+        <span><% convo_partner = @conversation.item.user %></span>  
       <% end %>
 
       <div class="d-flex justify-content-between align-items-center mb-2 mt-2">
         <div>
           <span><%= @conversation.item.name %></span>
-          <span class="convo_partner"><%= convo_partner %></span>
+          <span class="convo_partner"><%= convo_partner.username %></span>
           <% status = @conversation.item.status == 'open' ? '' : "(" + @conversation.item.status.capitalize + ")"%>
           <span class="status font-italic text-warning"><%= status %></span>
         </div>
 
+        <!-- only item owner can change item's status -->
         <% if @conversation.item.user == current_user %>
             <div class="item-status-update d-flex justify-content-around">
                 <% disabled = @conversation.item.status == 'traded' %>
@@ -67,11 +68,13 @@
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                            <%= form_with scope: :item, method: :patch, url: item_path(@conversation.item), local: true do |f| %>
+                            <!-- when item is marked as traded, a transaction instance is created -->
+                            <%= form_for @conversation.item do |f| %>
                                 <%= f.hidden_field :status, value: "traded" %>
+                                <%= f.hidden_field :buyer_id, value: convo_partner.id %>
                                 <%= f.submit "Proceed, mark as Traded", class: "btn btn-primary" %>
                             <% end %>
-                            <!--<button type="button" class="btn btn-primary">Understood</button>-->
+                            
                         </div>
                         </div>
                     </div>

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -12,20 +12,18 @@
 
     <ul class="nav-items-container nav nav-pills flex-column mb-auto">
         <li class="nav-item">
-            <a href="#" class="nav-link active" aria-current="page">
-                Dashboard
-            </a>
+            <%= link_to  "Dashboard", root_path, class: "nav-link active" %>
         </li>
-        <li>
+        <li class="nav-item">
             <%= link_to  "My listings", user_path(current_user), class: "nav-link link-dark" %>
         </li>
 
-        <li>
+        <li class="nav-item">
             <a type="button" class="nav-link link-dark" data-toggle="modal" data-target="#create-item-modal">
                 Create new listing
             </a>
         </li>
-        <li>
+        <li class="nav-item">
             <a href="#" class="nav-link link-dark">
                 History
             </a>

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -24,9 +24,7 @@
             </a>
         </li>
         <li class="nav-item">
-            <a href="#" class="nav-link link-dark">
-                History
-            </a>
+            <%= link_to "History", user_history_path(current_user), class: "nav-link link-dark" %>
         </li>
     </ul>
 

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -17,9 +17,7 @@
             </a>
         </li>
         <li>
-            <a href="#" class="nav-link link-dark">
-                My listings
-            </a>
+            <%= link_to  "My listings", user_path(current_user), class: "nav-link link-dark" %>
         </li>
 
         <li>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -11,7 +11,9 @@
       <% if @item != nil %>
         <div class="item">
           <div class="item_details">
-            <h6 class="item_description"><%= @item.user.username %></h6>
+            <h6 class="item_description">
+                <%= link_to @item.user.username, user_path(@item.user) %>
+            </h6>
             <% if user_signed_in? %>
               <% if current_user.id === @item.user_id %>
                 <div class="dropdown">

--- a/app/views/partials/_navbar.html.erb
+++ b/app/views/partials/_navbar.html.erb
@@ -27,16 +27,14 @@
             </div>
           </li>
           <li>
-            <!-- this should redirect to profile page instead -->
-            <a href="/">
+            <%= link_to user_path(current_user) do %>
                 <% if current_user.avatar.attached? %>
                   <%= image_tag url_for(current_user.thumbnail), size: '50x50', class: 'rounded-circle img-responsive', alt: 'profile avatar' %>
                 <% else %>
                   <% filepath = (current_user.id % 8).to_s + '.svg' %>
                   <%= image_tag 'default_avatars/' + filepath, size: '50x50', class: 'rounded-circle img-responsive', alt: 'profile avatar' %>
                 <% end %>
-                
-            </a>
+            <% end %>    
           </li>
 
         <% else %>

--- a/app/views/users/history.html.erb
+++ b/app/views/users/history.html.erb
@@ -1,26 +1,31 @@
-<div>This is <%= current_user.username %>'s history page</div>
+<section class="homepage">
+  <div class="container">
+    <%= render 'home/sidebar' %>
+    
+    <table class="table table-striped table-responsive">
+        <thead>
+            <tr>
+            <th scope="col">Item</th>
+            <th scope="col">Traded to</th>
+            <th scope="col">Traded with</th>
+            <th scope="col">Timestamp</th>
+            </tr>
+        </thead>
 
-<table class="table table-striped table-responsive">
-  <thead>
-    <tr>
-      <th scope="col">Item</th>
-      <th scope="col">Traded to</th>
-      <th scope="col">Traded with</th>
-      <th scope="col">Timestamp</th>
-    </tr>
-  </thead>
+        <tbody>
+            <% @history_items.each do |item| %>
+                <tr>
+                    <th scope="row"><%= item.name %></th>
+                    <td>
+                        <% traded_to = User.find(item.transact.user2_id) %>
+                        <%= link_to traded_to.username, user_path(item.transact.user2_id) %>
+                    </td>
+                    <td><%= item.transact.traded_with %></td>
+                    <td><%= item.transact.created_at.strftime("%d-%m-%Y %I:%M%p") %></td>
+                </tr>
+            <% end %>
+        </tbody>
+    </table>
 
-  <tbody>
-    <% @history_items.each do |item| %>
-        <tr>
-            <th scope="row"><%= item.name %></th>
-            <td>
-                <% traded_to = User.find(item.transact.user2_id) %>
-                <%= link_to traded_to.username, user_path(item.transact.user2_id) %>
-            </td>
-            <td><%= item.transact.traded_with %></td>
-            <td><%= item.transact.created_at.strftime("%d-%m-%Y %I:%M%p") %></td>
-        </tr>
-    <% end %>
-  </tbody>
-</table>
+  </div>
+</section>

--- a/app/views/users/history.html.erb
+++ b/app/views/users/history.html.erb
@@ -1,0 +1,26 @@
+<div>This is <%= current_user.username %>'s history page</div>
+
+<table class="table table-striped table-responsive">
+  <thead>
+    <tr>
+      <th scope="col">Item</th>
+      <th scope="col">Traded to</th>
+      <th scope="col">Traded with</th>
+      <th scope="col">Timestamp</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @history_items.each do |item| %>
+        <tr>
+            <th scope="row"><%= item.name %></th>
+            <td>
+                <% traded_to = User.find(item.transact.user2_id) %>
+                <%= link_to traded_to.username, user_path(item.transact.user2_id) %>
+            </td>
+            <td><%= item.transact.traded_with %></td>
+            <td><%= item.transact.created_at.strftime("%d-%m-%Y %I:%M%p") %></td>
+        </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/users/history.html.erb
+++ b/app/views/users/history.html.erb
@@ -15,7 +15,9 @@
         <tbody>
             <% @history_items.each do |item| %>
                 <tr>
-                    <th scope="row"><%= item.name %></th>
+                    <td scope="row">
+                        <%= link_to item.name, item_path(item) %>
+                    </td>
                     <td>
                         <% traded_to = User.find(item.transact.user2_id) %>
                         <%= link_to traded_to.username, user_path(item.transact.user2_id) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,1 @@
+<div> This is <%= @user.username %>'s profile page </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,18 @@
+<%= render 'home/sidebar' %>
+
 <div> This is <%= @user.username %>'s profile page </div>
+
+<div class="products">
+    <% @user.items.each do |item| %>
+        <%= link_to item_path(item) do %>
+            <div class="items">
+            <% if item.images.attached? %>
+                <%= image_tag item.images[0], class: "itempic" %>
+            <% else %>
+                <%= image_tag "altpic.png", class: "itempic" %>
+            <% end %>
+            <h5 class="item_name"><%= item.name %></h5>
+            </div>
+        <% end %>
+    <% end %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,18 +1,21 @@
-<%= render 'home/sidebar' %>
-
-<div> This is <%= @user.username %>'s profile page </div>
-
-<div class="products">
-    <% @user.items.each do |item| %>
-        <%= link_to item_path(item) do %>
-            <div class="items">
-            <% if item.images.attached? %>
-                <%= image_tag item.images[0], class: "itempic" %>
-            <% else %>
-                <%= image_tag "altpic.png", class: "itempic" %>
+<section class="homepage">
+  <div class="container">
+    <%= render 'home/sidebar' %>
+    
+    <div class="products">
+        <% @user.items.each do |item| %>
+            <%= link_to item_path(item) do %>
+                <div class="items">
+                <% if item.images.attached? %>
+                    <%= image_tag item.images[0], class: "itempic" %>
+                <% else %>
+                    <%= image_tag "altpic.png", class: "itempic" %>
+                <% end %>
+                <h5 class="item_name"><%= item.name %></h5>
+                </div>
             <% end %>
-            <h5 class="item_name"><%= item.name %></h5>
-            </div>
         <% end %>
-    <% end %>
-</div>
+    </div>
+
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,4 @@ Rails.application.routes.draw do
         resources :messages
     end
   end
-
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
       get :confirm_email
     end
   end
+
+  get 'users/:id/history' => 'users#history', as: 'user_history'
   
   root to: 'home#index'
   

--- a/db/migrate/20210719184829_create_transacts.rb
+++ b/db/migrate/20210719184829_create_transacts.rb
@@ -1,0 +1,11 @@
+class CreateTransacts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :transacts do |t|
+      t.integer :item_id
+      t.string :traded_with
+      t.integer :user1_id   # user1 is the 'seller'; the one who posted the listing
+      t.integer :user2_id   # user2 is the 'buyer'
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210719190604_adding_transact_id_col_in_items.rb
+++ b/db/migrate/20210719190604_adding_transact_id_col_in_items.rb
@@ -1,0 +1,5 @@
+class AddingTransactIdColInItems < ActiveRecord::Migration[6.0]
+  def change
+    add_column :items, :transact_id, :integer
+  end
+end

--- a/db/migrate/20210719191149_removing_unnecessary_user1_id_col_in_transacts.rb
+++ b/db/migrate/20210719191149_removing_unnecessary_user1_id_col_in_transacts.rb
@@ -1,0 +1,5 @@
+class RemovingUnnecessaryUser1IdColInTransacts < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :transacts, :user1_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_184829) do
+ActiveRecord::Schema.define(version: 2021_07_19_191149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2021_07_19_184829) do
     t.string "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "transact_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -84,7 +85,6 @@ ActiveRecord::Schema.define(version: 2021_07_19_184829) do
   create_table "transacts", force: :cascade do |t|
     t.integer "item_id"
     t.string "traded_with"
-    t.integer "user1_id"
     t.integer "user2_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_17_230700) do
+ActiveRecord::Schema.define(version: 2021_07_19_184829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,15 @@ ActiveRecord::Schema.define(version: 2021_07_17_230700) do
     t.text "description"
     t.integer "rate_poster"
     t.integer "rate_commenter"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "transacts", force: :cascade do |t|
+    t.integer "item_id"
+    t.string "traded_with"
+    t.integer "user1_id"
+    t.integer "user2_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/notepad.md
+++ b/notepad.md
@@ -55,5 +55,5 @@
     1. add channel broadcast when item's status is changed
     2. deleting listing should prompt a verification modal
     3. in conversation show page, add main item image in conversation name
-    4. add image carousel for item images
-    5. entire conversation history between 2 users should not be loaded all at once when visiting a conversation show page
+    4. entire conversation history between 2 users should not be loaded all at once when visiting a conversation show page
+    5. in user's profile page, items should be grouped in terms of status

--- a/notepad.md
+++ b/notepad.md
@@ -48,8 +48,12 @@
 
     7. No button to redirect to home when user is not signed in
     
+    8. Chat avatar is late to appear when a message is sent
+
+    9. (not a bug) create and delete of transaction is kinda hacky; can't make nested forms work so resorted to the workaround for now
 ## minor details to add:
     1. add channel broadcast when item's status is changed
     2. deleting listing should prompt a verification modal
     3. in conversation show page, add main item image in conversation name
     4. add image carousel for item images
+    5. entire conversation history between 2 users should not be loaded all at once when visiting a conversation show page


### PR DESCRIPTION
This PR does the following:

1. Adds a transaction model. A transaction instance is created when the item owner changes an item's status to 'traded'. Changing back the item's status to 'open' deletes the transaction. Future updates will deprecate user's ability to change a 'traded' item back to 'open'. A traded item's status will remain as such and the only option left for it is to delete it if the user wishes to.

2. Creates show page for users' profile [WIP]
  ![image](https://user-images.githubusercontent.com/72240605/126245485-7040fe13-9ce7-4826-b5f6-d1b7d797a6b8.png)

3. Creates history page for users' transactions [WIP]
  ![image](https://user-images.githubusercontent.com/72240605/126245560-14605b58-ca1a-44f4-be1f-add350af57d7.png)

