### PR TITLE
Features/james/bugfixes and improvements

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -44,47 +44,28 @@
   margin-top: 0.5rem;
 }
 
-// .tmp-sidebar {
-//   position: absolute;
-//   left: 0;
-//   top: 0;
-//   bottom: 0;
-//   box-shadow: rgba(0, 0, 0, 0.15) 2.4px 2.4px 3.2px;
+//----------- image-stack -----------
+.image-stack {
+    width: auto;
+    padding: 0;
+}
 
-//   .hello-username {
-//     height: 5rem;
-//     margin-bottom: 20px !important;
-//   }
+.image-stack::after {
+  content: '';
+  display: table;
+  clear: both;
+}
 
-//   .conversations {
-//     height: 60vh;
-//     overflow-y: auto;
+.image-stack__item--top {
+    float: left;
+    width: 66%;
+    margin-right: -100%;
+    padding-top: 15%; // arbitrary
+    position: relative;
+    z-index: 1;
+}
 
-//     .nav-item {
-//       border-radius: 5px;
-
-//       &:hover {
-//         background-color: #e0e0e0;
-//       }
-
-//       &.active {
-//         background-color: #007bff;
-
-//         .convo-item-name {
-//           color: white;
-//         }
-
-//         .other-user-username {
-//           color: #5a5a5a;
-//         }
-//       }
-
-//       .other-user-username {
-//         font-size: 0.8rem;
-//         color: #777777;
-//       }
-//     }
-//   }
-
-//   // Comment
-// }
+.image-stack__item--bottom {
+    float: right;
+    width: 75%;
+}

--- a/app/javascript/channels/conversation_channel.js
+++ b/app/javascript/channels/conversation_channel.js
@@ -9,7 +9,9 @@ document.addEventListener('turbolinks:load', () => {
 
     // for terminating other subscriptions when connected to a new subscription
     consumer.subscriptions.subscriptions.forEach(subs => {
+        // console.log("disconnected to conversation: " + JSON.parse(subs.identifier).conversation_id);
         consumer.subscriptions.remove(subs);
+        
     });
 
     consumer.subscriptions.create({ channel: "ConversationChannel", conversation_id: conversation_id }, {
@@ -39,6 +41,3 @@ document.addEventListener('turbolinks:load', () => {
         }
       });
 });
-
-
-

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,6 +2,8 @@ class Message < ApplicationRecord
   belongs_to :conversation, class_name: 'Conversation'
   belongs_to :user, class_name: 'User'
 
+  validates :content, presence: true
+
   def sender
     user_id
   end

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,17 +1,17 @@
 <div class="comment-container" id= "comment<%= t.id %>">
     <% commenter = User.find_by(id: t.user.id) %>
     <div class="d-flex flex-row">
-        <% if commenter.avatar.attached? %>
-            <%= image_tag url_for(commenter.thumbnail), size: '40x40', class: 'rounded-circle img-responsive', alt: 'profile avatar' %>
-        <% else %>
-            <% filepath = (commenter.id % 8).to_s + '.png' %>
-            <%= image_tag 'default_avatars/' + filepath, size: '40x40', class: 'rounded-circle img-responsive', alt: 'profile avatar' %>
+        <%= link_to user_path(commenter) do %>
+            <% if commenter.avatar.attached? %>
+                <%= image_tag url_for(commenter.thumbnail), size: '40x40', class: 'rounded-circle img-responsive', alt: 'profile avatar' %>
+            <% else %>
+                <% filepath = (commenter.id % 8).to_s + '.png' %>
+                <%= image_tag 'default_avatars/' + filepath, size: '40x40', class: 'rounded-circle img-responsive', alt: 'profile avatar' %>
+            <% end %>
         <% end %>
+
         <div class="d-flex flex-column justify-content-start p-2 ml-3 rounded-lg author-content">
-            <!-- TO FOLLOW: make this link to profile page -->
-            <p class="commenter pl-1 m-0 font-weight-bold">
-                <%= commenter.first_name %> <%= commenter.last_name %>
-            </p>
+            <%= link_to commenter.username, user_path(commenter), class: "commenter pl-1 m-0 font-weight-bold" %>
             <p class="pl-2 m-0 content"><%= t.body %></p>
         </div>
 

--- a/app/views/conversations/_conversations.html.erb
+++ b/app/views/conversations/_conversations.html.erb
@@ -52,12 +52,12 @@
                     <% if item.status != 'reserved' %>
                         <%= form_with scope: :item, method: :patch, url: item_path(item), local: true do |f| %>
                             <%= f.hidden_field :status, value: "reserved" %>
-                            <%= f.submit "Mark as Reserved", disabled: disabled, class: "btn btn-primary ml-1 mr-1" %>
+                            <%= f.submit "Mark as Reserved", disabled: disabled, class: "btn btn-secondary ml-1 mr-1" %>
                         <% end %>
                     <% else %>
                         <%= form_with scope: :item, method: :patch, url: item_path(item), local: true do |f| %>
                             <%= f.hidden_field :status, value: "open" %>
-                            <%= f.submit "Mark as Open", disabled: disabled, class: "btn btn-primary ml-1 mr-1" %>
+                            <%= f.submit "Mark as Open", disabled: disabled, class: "btn btn-secondary ml-1 mr-1" %>
                         <% end %>
                     <% end %>
                     <button type="button" class="btn btn-primary ml-1 mr-1" data-toggle="modal" data-target="#staticBackdrop">Mark as Traded</button>

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -37,7 +37,7 @@
             <% if conv.item != nil %>
                     <%= link_to item_conversation_path(conv.item_id, conv.id), class: "nav-link" do %>
                         <% active_class = (@conversation == conv) ? 'active' : '' %>
-                        <li class="nav-item d-flex flex-row align-items-center <%= active_class %>">   
+                        <li class="nav-item d-flex flex-row align-items-center pl-1 <%= active_class %>">   
                             <!-- getting username of current_user's conversation partner -->
                             <% if conv.item.user == current_user && current_user.id == conv.user2_id %>
                                 <% convo_partner = User.find(conv.user1_id) %>

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -65,7 +65,11 @@
                             </div>
 
                             <div class="d-flex flex-column align-items-center m-auto">
-                                <span class="convo-item-name"><%= conv.item.name %></span>
+                                <span class="convo-item-name">
+                                    <%= conv.item.name %>
+                                    <% status = conv.item.status == 'open' ? '' : "(" + conv.item.status.capitalize + ")"%>
+                                    <span class="status font-italic text-warning"><%= status %></span>
+                                </span>
                                 <span class="other-user-username"><%= convo_partner.username %></span>
                             </div>
 

--- a/app/views/home/_sidebar.html.erb
+++ b/app/views/home/_sidebar.html.erb
@@ -47,13 +47,22 @@
                                 <% convo_partner = conv.item.user %>
                             <% end %>
 
-                            <% if convo_partner.avatar.attached? %>
-                                <%= image_tag url_for(convo_partner.thumbnail), size: '30x30', class: 'rounded-circle img-responsive ml-2', alt: 'profile avatar' %>
-                            <% else %>
-                                <%# filepath = (current_user.id % 8).to_s + '.svg' %>
-                                <% filepath = (current_user.id % 8).to_s + '.png' %>
-                                <%= image_tag 'default_avatars/' + filepath, size: '30x30', class: 'rounded-circle img-responsive ml-2', alt: 'profile avatar'  %>
-                            <% end %>
+                            <!-- image stack -->
+                            <div class="image-stack-container">
+                                <div class="image-stack">
+                                    <div class="image-stack__item image-stack__item--top">
+                                        <% if convo_partner.avatar.attached? %>
+                                            <%= image_tag url_for(convo_partner.thumbnail), size: '30x30', class: 'rounded-circle img-responsive', alt: 'profile avatar' %>
+                                        <% else %>
+                                            <% filepath = (current_user.id % 8).to_s + '.png' %>
+                                            <%= image_tag 'default_avatars/' + filepath, size: '30x30', class: 'rounded-circle img-responsive', alt: 'profile avatar'  %>
+                                        <% end %>
+                                    </div>
+                                    <div class="image-stack__item image-stack__item--bottom">
+                                        <%= image_tag conv.item.images[0], size: '30x30', class: 'rounded-circle img-responsive' %>
+                                    </div>
+                                </div>
+                            </div>
 
                             <div class="d-flex flex-column align-items-center m-auto">
                                 <span class="convo-item-name"><%= conv.item.name %></span>

--- a/app/views/items/_products_item.html.erb
+++ b/app/views/items/_products_item.html.erb
@@ -21,8 +21,12 @@
           <% end %>
         <% end %>
       </div>
-
-      <h5 class="item_name"><%= @item.name %></h5>
+    
+      <% status = @item.status == 'open' ? '' : "(" + @item.status.capitalize + ")"%>
+      <h5 class="item_name">
+        <%= @item.name %>
+        <span class="status font-italic text-warning fw-light"><%= status %></span>
+      </h5>
       <h6 class="item_description"><%= @item.description %></h6>
 
       <!-- make carousel for item images -->

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -5,11 +5,11 @@
     </div>
 
     <div class="right-content">
-      <%= render 'products_items'%>
+      <%= render 'products_item'%>
     </div>    
   </div>
 <% else %>
   <div class="container">
-    <%= render 'products_items'%>
+    <%= render 'products_item'%>
   </div>
 <% end %>

--- a/app/views/users/_history-list.html.erb
+++ b/app/views/users/_history-list.html.erb
@@ -23,7 +23,7 @@
               <% traded_to = item.user %>
             <% end %>
             
-            <%= link_to traded_to.username, user_path(item.transact.user2_id) %>
+            <%= link_to traded_to.username, user_path(traded_to) %>
           </td>
           <td><%= item.transact.traded_with %></td>
           <td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,7 +13,12 @@
               <% else %>
                 <%= image_tag "altpic.png", class: "itempic" %>
               <% end %>
-              <h5 class="item_name"><%= item.name %></h5>
+              
+              <% status = item.status == 'open' ? '' : "(" + item.status.capitalize + ")"%>
+              <h5 class="item_name">
+                <%= item.name %>
+                <span class="status font-italic text-warning fst-normal"><%= status %></span>
+              </h5>
             </div>
           <% end %>
         <% end %>

--- a/notepad.md
+++ b/notepad.md
@@ -54,7 +54,7 @@
     2. deleting listing should prompt a verification modal
     3. entire conversation history between 2 users should not be loaded all at once when visiting a conversation show page
     4. in user's profile page, items should be grouped in terms of status
-    5. add links to avatar, first_name last_name, in comment section
-    6. preview for uploaded images
-    7. conversations should be tagged as traded when item is traded
+    5. preview for uploaded images
 
+## major details to add:
+    1. pagination in root page

--- a/notepad.md
+++ b/notepad.md
@@ -50,11 +50,14 @@
 
     8. (not a bug) create and delete of transaction is kinda hacky; can't make nested forms work so resorted to the workaround for now
 
-    9. item should appear in the history of both user1 and user2. currently, it only appear in user1's history
-
+    9. listings fail to edit in production
 ## minor details to add:
     1. add channel broadcast when item's status is changed
     2. deleting listing should prompt a verification modal
     3. in conversation show page, add main item image in conversation name
     4. entire conversation history between 2 users should not be loaded all at once when visiting a conversation show page
     5. in user's profile page, items should be grouped in terms of status
+    6. add links to avatar, first_name last_name, in comment section
+    7. preview for uploaded images
+    8. conversations should be tagged as traded when item is traded
+

--- a/notepad.md
+++ b/notepad.md
@@ -33,31 +33,28 @@
     run: heroku config:set RAILS_MASTER_KEY=`cat config/master.key`
 
 ## bugs to fix:
-    1. when an exchange happened in a conversation, sometimes clicking on another conversation and clicking back to the previous conversation, the previous conversation doesn't show the recent exchange
+    1. after subscribing to a conversation, clicking a link other than the conversation links does not unsubscribe the user in the current conversation channel; clicking kalakalph which redirects the user to root should terminate the channel subscription
 
-    2. after subscribing to a conversation, clicking a link other than the conversation links does not unsubscribe the user in the current conversation channel; clicking kalakalph which redirects the user to root should terminate the channel subscription
-
-    3. timestamp not working for newly sent messages but refreshing the page fixes it
+    2. timestamp not working for newly sent messages but refreshing the page fixes it
         - maybe time interval between two consecutive messages should be calculated in the background job
 
-    4. if a user who participated in any conversation is deleted, app gets an error in displaying conversation partners
+    3. if a user who participated in any conversation is deleted, app gets an error in displaying conversation partners
 
-    5. when attempting to create or update a listing with validation errors; validation errors don't appear
+    4. when attempting to create or update a listing with validation errors; validation errors don't appear
 
-    6. No button to redirect to home when user is not signed in
+    5. No button to redirect to home when user is not signed in
     
-    7. Chat avatar is late to appear when a message is sent
+    6. Chat avatar is late to appear when a message is sent
 
-    8. (not a bug) create and delete of transaction is kinda hacky; can't make nested forms work so resorted to the workaround for now
+    7. (not a bug) create and delete of transaction is kinda hacky; can't make nested forms work so resorted to the workaround for now
 
-    9. listings fail to edit in production
+    8. listings fail to edit in production
 ## minor details to add:
     1. add channel broadcast when item's status is changed
     2. deleting listing should prompt a verification modal
-    3. in conversation show page, add main item image in conversation name
-    4. entire conversation history between 2 users should not be loaded all at once when visiting a conversation show page
-    5. in user's profile page, items should be grouped in terms of status
-    6. add links to avatar, first_name last_name, in comment section
-    7. preview for uploaded images
-    8. conversations should be tagged as traded when item is traded
+    3. entire conversation history between 2 users should not be loaded all at once when visiting a conversation show page
+    4. in user's profile page, items should be grouped in terms of status
+    5. add links to avatar, first_name last_name, in comment section
+    6. preview for uploaded images
+    7. conversations should be tagged as traded when item is traded
 


### PR DESCRIPTION
This PR fixes the following minor bugs and added the following improvements:

1. added image stack of conversation partner's avatar and item image in conversation list within the sidebar; also added item status in beside item name in user's profile page (will only show if item is traded or reserved)
  ![image](https://user-images.githubusercontent.com/72240605/126572023-5f1488ae-c7d1-437e-b908-d57178cf20c7.png)

2. changed button colors for marking item as reserved or open (refer to the photo above)
3. fixed trade partner link in history page pointing to the wrong user
4. disable sending messages containing white spaces only
